### PR TITLE
抑制对 `PUBLIC_MESSAGE_DELETE` 类型事件的解析错误异常

### DIFF
--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/EventSignals.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/EventSignals.kt
@@ -87,6 +87,7 @@ public sealed class EventSignals<out D : Any>(
                 "AUDIO_ON_MIC" to AudioAction.AudioOnMic,
                 "AUDIO_OFF_MIC" to AudioAction.AudioOffMic,
                 "AT_MESSAGE_CREATE" to AtMessages.AtMessageCreate,
+                "PUBLIC_MESSAGE_DELETE" to AtMessages.PublicMessageDelete,
             )
         }
     }
@@ -169,7 +170,7 @@ public sealed class EventSignals<out D : Any>(
 
             @JvmStatic
             public val intentsValue: Int
-                get() = AtMessages.intents.value
+                get() = intents.value
         }
     }
 
@@ -191,7 +192,7 @@ public sealed class EventSignals<out D : Any>(
 
             @JvmStatic
             public val intentsValue: Int
-                get() = AtMessages.intents.value
+                get() = intents.value
         }
     }
 
@@ -207,7 +208,7 @@ public sealed class EventSignals<out D : Any>(
 
             @JvmStatic
             public val intentsValue: Int
-                get() = AtMessages.intents.value
+                get() = intents.value
         }
     }
 
@@ -230,7 +231,7 @@ public sealed class EventSignals<out D : Any>(
 
             @JvmStatic
             public val intentsValue: Int
-                get() = AtMessages.intents.value
+                get() = intents.value
         }
     }
 
@@ -239,6 +240,9 @@ public sealed class EventSignals<out D : Any>(
         /** 当收到@机器人的消息时 */
         public object AtMessageCreate : AtMessages<TencentMessage>("AT_MESSAGE_CREATE", TencentMessage.serializer)
 
+        // 文档内暂无描述，因此暂时不支持解析
+        public object PublicMessageDelete : AtMessages<Unit>("PUBLIC_MESSAGE_DELETE", Unit.serializer())
+        
         public companion object {
             @JvmSynthetic
             public val intents: Intents = Intents(1 shl 30)

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/internal/TencentMessageImpl.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/internal/TencentMessageImpl.kt
@@ -17,9 +17,12 @@
 
 package love.forte.simbot.tencentguild.internal
 
-import kotlinx.serialization.*
-import love.forte.simbot.*
-import love.forte.simbot.tencentguild.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import love.forte.simbot.CharSequenceID
+import love.forte.simbot.Timestamp
+import love.forte.simbot.tencentguild.TencentMessage
+import love.forte.simbot.tencentguild.TimestampISO8601Serializer
 
 @Serializable
 internal data class TencentMessageImpl(
@@ -30,7 +33,7 @@ internal data class TencentMessageImpl(
     override val guildId: CharSequenceID,
     override val content: String,
     @Serializable(TimestampISO8601Serializer::class)
-    override val timestamp: Timestamp,
+    override val timestamp: Timestamp = Timestamp.NotSupport,
     @SerialName("edited_timestamp")
     override val editedTimestamp: Timestamp = Timestamp.NotSupport,
     @SerialName("mention_everyone")


### PR DESCRIPTION
但是仅抑制错误。此事件文档中暂无结构说明，因此暂时不做解析，以 `Unit` 为序列化目标。

因此本次仅算作 _缺陷修补_，但并未从根本上解决。

see #37 