### PR TITLE
变更所有API风格为工厂式

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -59,7 +59,7 @@ object P {
             0, 0
         )
 
-        private val alphaSuffix = v("alpha", 3)
+        private val alphaSuffix = v("alpha", 4)
 
         override val version = baseVersion - alphaSuffix
         val snapshotVersion = baseVersion - (alphaSuffix - Version.SNAPSHOT)

--- a/simbot-component-tencent-guild-api/build.gradle.kts
+++ b/simbot-component-tencent-guild-api/build.gradle.kts
@@ -44,7 +44,6 @@ plugins {
 
 dependencies {
     api(simbotApi)
-    api(kotlin("reflect"))
 
     api(libs.ktor.client.core)
     api(libs.ktor.client.cio)

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/TencentGuildObjective.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/TencentGuildObjective.kt
@@ -3,7 +3,7 @@ package love.forte.simbot.tencentguild
 
 /**
  *
- * 用于标记一个腾讯频道API中所提供的实体对象的接口。
+ * 用于标记一个QQ频道API中所提供的实体对象的接口。
  *
  * @author ForteScarlet
  */

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/ApiRequestUtil.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/ApiRequestUtil.kt
@@ -21,57 +21,15 @@ package love.forte.simbot.tencentguild.api
 
 import io.ktor.client.*
 import io.ktor.http.*
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.StringFormat
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonBuilder
 import love.forte.simbot.Api4J
 import love.forte.simbot.logger.LoggerFactory
-import love.forte.simbot.tencentguild.InternalSrTcgApi
+import love.forte.simbot.utils.runInNoScopeBlocking
 import java.util.function.Consumer
 
 internal val logger = LoggerFactory.getLogger("love.forte.simbot.tencentguild.api.request")
-
-// @JvmSynthetic
-// public suspend fun TencentApi<*>.requestForResponse(
-//     client: HttpClient,
-//     server: Url,
-//     token: String,
-// ): HttpResponse {
-//     val api = this
-//
-//     return client.request {
-//         method = api.method
-//
-//         headers {
-//             this[HttpHeaders.Authorization] = token
-//         }
-//
-//         url {
-//             // route builder
-//             val routeBuilder = RouteInfoBuilder { name, value ->
-//                 parameters.append(name, value.toString())
-//             }
-//
-//             api.route(routeBuilder)
-//             api.body?.also { b -> body = b }
-//
-//             protocol = server.protocol
-//             host = server.host
-//             path(routeBuilder.apiPath)
-//             routeBuilder.contentType?.let {
-//                 headers {
-//                     this[HttpHeaders.ContentType] = it.toString()
-//                 }
-//             }
-//             // val contentType = routeBuilder.contentType
-//             // if (contentType != null) {
-//             //     contentType(contentType)
-//             // }
-//         }
-//
-//     }
-// }
 
 /**
  *
@@ -98,7 +56,6 @@ public suspend fun <R> TencentApi<R>.request(
 /**
  * for Java
  */
-@OptIn(InternalSrTcgApi::class)
 @Api4J
 @JvmOverloads
 public fun <R> doRequest(
@@ -107,7 +64,7 @@ public fun <R> doRequest(
     server: String,
     token: String,
     decoder: StringFormat = defaultJson,
-): R = runBlocking {
+): R = runInNoScopeBlocking {
     api.request(client, Url(server), token, decoder)
 }
 

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/GatewayApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/GatewayApi.kt
@@ -35,7 +35,7 @@ import love.forte.simbot.tencentguild.api.GatewayApis.Shared
  * @author ForteScarlet
  */
 public sealed class GatewayApis<R : GatewayInfo>(
-    protected val path: List<String>,
+    protected val path: Array<String>,
     override val resultDeserializer: DeserializationStrategy<R>
 ) : GetTencentApi<R>() {
     
@@ -48,7 +48,7 @@ public sealed class GatewayApis<R : GatewayInfo>(
      *
      * > [参考文档](https://bot.q.qq.com/wiki/develop/api/openapi/wss/url_get.html)
      */
-    public object Normal : GatewayApis<Gateway>(listOf("gateway"), Gateway.serializer())
+    public object Normal : GatewayApis<Gateway>(arrayOf("gateway"), Gateway.serializer())
     
     
     /**
@@ -56,7 +56,7 @@ public sealed class GatewayApis<R : GatewayInfo>(
      *
      * > [参考文档](https://bot.q.qq.com/wiki/develop/api/openapi/wss/shard_url_get.html)
      */
-    public object Shared : GatewayApis<GatewayWithShard>(listOf("gateway", "bot"), GatewayWithShard.serializer())
+    public object Shared : GatewayApis<GatewayWithShard>(arrayOf("gateway", "bot"), GatewayWithShard.serializer())
 }
 
 

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/GatewayApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/GatewayApi.kt
@@ -18,18 +18,44 @@
 package love.forte.simbot.tencentguild.api
 
 import kotlinx.serialization.*
+import love.forte.simbot.tencentguild.api.GatewayApis.Normal
+import love.forte.simbot.tencentguild.api.GatewayApis.Shared
 
 
+/**
+ * 获取网关信息。
+ *
+ * 通过 [Normal] 或 [Shared] 的形式根据bot信息获取使用 Websocket 接入时间通知的链接。
+ *
+ * > [参考文档](https://bot.q.qq.com/wiki/develop/api/gateway/reference.html)
+ *
+ * @see Normal
+ * @see Shared
+ *
+ * @author ForteScarlet
+ */
 public sealed class GatewayApis<R : GatewayInfo>(
     protected val path: List<String>,
     override val resultDeserializer: DeserializationStrategy<R>
 ) : GetTencentApi<R>() {
-
+    
     override fun route(builder: RouteInfoBuilder) {
         builder.apiPath = path
     }
-
+    
+    /**
+     * 获取通用 WSS 接入点
+     *
+     * > [参考文档](https://bot.q.qq.com/wiki/develop/api/openapi/wss/url_get.html)
+     */
     public object Normal : GatewayApis<Gateway>(listOf("gateway"), Gateway.serializer())
+    
+    
+    /**
+     * 获取带分片 WSS 接入点
+     *
+     * > [参考文档](https://bot.q.qq.com/wiki/develop/api/openapi/wss/shard_url_get.html)
+     */
     public object Shared : GatewayApis<GatewayWithShard>(listOf("gateway", "bot"), GatewayWithShard.serializer())
 }
 
@@ -43,8 +69,9 @@ public sealed class GatewayInfo {
 }
 
 /**
- * [https://bot.q.qq.com/wiki/develop/api/openapi/wss/url_get.html#%E8%BF%94%E5%9B%9E]
- * 一个用于连接 websocket 的地址。
+ * 一个用于连接 websocket 的地址。[GatewayApis.Normal] 的响应体。
+ *
+ * > [参考文档](https://bot.q.qq.com/wiki/develop/api/openapi/wss/url_get.html#%E8%BF%94%E5%9B%9E)
  */
 @SerialName("n")
 @Serializable
@@ -52,8 +79,10 @@ public data class Gateway(override val url: String) : GatewayInfo()
 
 
 /**
- * [https://bot.q.qq.com/wiki/develop/api/openapi/wss/shard_url_get.html#%E8%BF%94%E5%9B%9E]
  * 一个用于连接 websocket 的地址。同时返回建议的分片数，以及目前连接数使用情况。
+ * [GatewayApis.Shared] 的响应体。
+ *
+ * [参考文档](https://bot.q.qq.com/wiki/develop/api/openapi/wss/shard_url_get.html#%E8%BF%94%E5%9B%9E)
  */
 @SerialName("s")
 @Serializable
@@ -66,8 +95,8 @@ public data class GatewayWithShard(
 
 
 /**
- * [https://bot.q.qq.com/wiki/develop/api/openapi/wss/shard_url_get.html#sessionstartlimit]
  *
+ * [参考文档](https://bot.q.qq.com/wiki/develop/api/openapi/wss/shard_url_get.html#sessionstartlimit)
  */
 @Serializable
 public data class SessionStartLimit(

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/RouteInfoBuilder.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/RouteInfoBuilder.kt
@@ -19,7 +19,6 @@ package love.forte.simbot.tencentguild.api
 
 import io.ktor.http.*
 
-
 public class RouteInfoBuilder(public val parametersAppender: ParametersAppender) {
     /**
      * 可以设置api路径

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/RouteInfoBuilder.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/RouteInfoBuilder.kt
@@ -19,11 +19,15 @@ package love.forte.simbot.tencentguild.api
 
 import io.ktor.http.*
 
+/**
+ * @suppress internal type
+ */
 public class RouteInfoBuilder(public val parametersAppender: ParametersAppender) {
     /**
      * 可以设置api路径
      */
-    public var apiPath: List<String> = emptyList()
+    public var apiPath: Array<out String>? = null
+    
     
     /**
      * 请求头中的 [ContentType], 绝大多数情况下，此参数默认为 [ContentType.Application.Json].

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/Serializers.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/Serializers.kt
@@ -26,15 +26,15 @@ import kotlinx.serialization.encoding.Encoder
 
 
 /**
- * `0` -> false
- * other -> true, decode true to `1`
+ * - `0` -> false
+ * - other -> true, decode true to `1`
  */
 public object BooleanToNumber : KSerializer<Boolean> {
     override fun deserialize(decoder: Decoder): Boolean {
         return decoder.decodeInt() != 0
     }
 
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BooleanToByte", PrimitiveKind.BOOLEAN)
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BooleanToInt", PrimitiveKind.BOOLEAN)
 
     override fun serialize(encoder: Encoder, value: Boolean) {
         encoder.encodeByte(if (value) 1 else 0)

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/TencentApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/TencentApi.kt
@@ -115,7 +115,7 @@ private suspend fun TencentApi<*>.requestForResponse(client: HttpClient, server:
             
             protocol = server.protocol
             host = server.host
-            appendPathSegments(routeBuilder.apiPath)
+            routeBuilder.apiPath?.let { apiPath -> appendPathSegments(components = apiPath) }
             routeBuilder.contentType?.let {
                 headers {
                     this[HttpHeaders.ContentType] = it.toString()

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/TencentApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/TencentApi.kt
@@ -32,7 +32,7 @@ import love.forte.simbot.tencentguild.err
 
 
 /**
- * 表示为一个腾讯频道的API。
+ * 表示为一个QQ频道的API。
  *
  * 通过 [doRequest] 发起一次请求。
  *

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/announces/CreateAnnouncesApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/announces/CreateAnnouncesApi.kt
@@ -55,7 +55,7 @@ public class CreateAnnouncesApi internal constructor(
     
     
     // POST /channels/{channel_id}/announces
-    private val path = listOf("channels", channelId.toString(), "announces")
+    private val path = arrayOf("channels", channelId.toString(), "announces")
     
     override val resultDeserializer: DeserializationStrategy<TencentAnnounces>
         get() = TencentAnnounces.serializer

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/announces/CreateAnnouncesApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/announces/CreateAnnouncesApi.kt
@@ -29,16 +29,30 @@ import love.forte.simbot.tencentguild.api.TencentApi
 
 /**
  *
+ * 机器人设置消息为指定子频道公告。
+ *
  * [创建子频道公告](https://bot.q.qq.com/wiki/develop/api/openapi/announces/post_channel_announces.html)
  *
- * 机器人设置消息为指定子频道公告
  *
  * @author ForteScarlet
  */
-public class CreateAnnouncesApi(
+public class CreateAnnouncesApi internal constructor(
     channelId: ID,
     messageId: ID,
 ) : TencentApi<TencentAnnounces>() {
+    
+    public companion object Factory {
+        
+        /**
+         * 构建 [CreateAnnouncesApi]
+         * @param channelId 频道ID
+         * @param messageId 消息ID
+         */
+        @JvmStatic
+        public fun create(channelId: ID, messageId: ID): CreateAnnouncesApi = CreateAnnouncesApi(channelId, messageId)
+        
+    }
+    
     
     // POST /channels/{channel_id}/announces
     private val path = listOf("channels", channelId.toString(), "announces")
@@ -58,9 +72,8 @@ public class CreateAnnouncesApi(
     
     @Serializable
     private data class Body(
-        @SerialName("message_id")
-        @Serializable(ID.AsCharSequenceIDSerializer::class)
-        val messageId: ID,
+        @SerialName("message_id") @Serializable(ID.AsCharSequenceIDSerializer::class) val messageId: ID,
     )
+    
     
 }

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/announces/DeleteAnnouncesApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/announces/DeleteAnnouncesApi.kt
@@ -46,7 +46,7 @@ public class DeleteAnnouncesApi internal constructor(
     }
     
     // DELETE /channels/{channel_id}/announces/{message_id}
-    private val path = listOf("channels", channelId.toString(), "announces", messageId.toString())
+    private val path = arrayOf("channels", channelId.toString(), "announces", messageId.toString())
     
     override val method: HttpMethod
         get() = HttpMethod.Delete

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/announces/DeleteAnnouncesApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/announces/DeleteAnnouncesApi.kt
@@ -31,10 +31,19 @@ import love.forte.simbot.tencentguild.api.TencentApiWithoutResult
  *
  * @author ForteScarlet
  */
-public class DeleteAnnouncesApi(
+public class DeleteAnnouncesApi internal constructor(
     channelId: ID,
     messageId: ID,
 ) : TencentApiWithoutResult() {
+    
+    public companion object Factory {
+        
+        /**
+         * 构造 [DeleteAnnouncesApi]
+         */
+        @JvmStatic
+        public fun create(channelId: ID, messageId: ID): DeleteAnnouncesApi = DeleteAnnouncesApi(channelId, messageId)
+    }
     
     // DELETE /channels/{channel_id}/announces/{message_id}
     private val path = listOf("channels", channelId.toString(), "announces", messageId.toString())

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/GetChannelApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/GetChannelApi.kt
@@ -29,7 +29,17 @@ import love.forte.simbot.tencentguild.api.RouteInfoBuilder
  *
  * @author ForteScarlet
  */
-public class GetChannelApi(channelId: ID) : GetTencentApi<TencentChannelInfo>() {
+public class GetChannelApi internal constructor(channelId: ID) : GetTencentApi<TencentChannelInfo>() {
+    
+    public companion object Factory {
+    
+        /**
+         * 构造 [GetChannelApi]
+         */
+        @JvmStatic
+        public fun create(channelId: ID): GetChannelApi = GetChannelApi(channelId)
+    }
+    
     // GET /channels/{channel_id}
     private val path = listOf("channels", channelId.toString())
 

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/GetChannelApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/GetChannelApi.kt
@@ -41,7 +41,7 @@ public class GetChannelApi internal constructor(channelId: ID) : GetTencentApi<T
     }
     
     // GET /channels/{channel_id}
-    private val path = listOf("channels", channelId.toString())
+    private val path = arrayOf("channels", channelId.toString())
 
     override val resultDeserializer: DeserializationStrategy<TencentChannelInfo>
         get() = TencentChannelInfo.serializer

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/GetGuildChannelListApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/GetGuildChannelListApi.kt
@@ -35,14 +35,6 @@ public class GetGuildChannelListApi internal constructor(guildId: ID) : GetTence
     
     public companion object Factory {
         private val serializer = ListSerializer(TencentChannelInfo.serializer)
-    
-        /**
-         * @suppress hidden
-         */
-        @JvmField
-        @JvmSynthetic
-        @Deprecated("renamed to Factory", level = DeprecationLevel.HIDDEN)
-        public val Companion: Factory = Factory // 二进制兼容..也许?
         
         /**
          * 构造 [GetGuildChannelListApi]

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/GetGuildChannelListApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/GetGuildChannelListApi.kt
@@ -31,7 +31,26 @@ import love.forte.simbot.tencentguild.api.RouteInfoBuilder
  *
  * @author ForteScarlet
  */
-public class GetGuildChannelListApi(guildId: ID) : GetTencentApi<List<TencentChannelInfo>>() {
+public class GetGuildChannelListApi internal constructor(guildId: ID) : GetTencentApi<List<TencentChannelInfo>>() {
+    
+    public companion object Factory {
+        private val serializer = ListSerializer(TencentChannelInfo.serializer)
+    
+        /**
+         * @suppress hidden
+         */
+        @JvmField
+        @JvmSynthetic
+        @Deprecated("renamed to Factory", level = DeprecationLevel.HIDDEN)
+        public val Companion: Factory = Factory // 二进制兼容..也许?
+        
+        /**
+         * 构造 [GetGuildChannelListApi]
+         */
+        @JvmStatic
+        public fun create(guildId: ID): GetGuildChannelListApi = GetGuildChannelListApi(guildId)
+    }
+    
     // GET /guilds/{guild_id}/channels
     private val path = listOf("guilds", guildId.toString(), "channels")
 
@@ -42,7 +61,4 @@ public class GetGuildChannelListApi(guildId: ID) : GetTencentApi<List<TencentCha
         builder.apiPath = path
     }
 
-    public companion object {
-        private val serializer = ListSerializer(TencentChannelInfo.serializer)
-    }
 }

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/GetGuildChannelListApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/GetGuildChannelListApi.kt
@@ -44,7 +44,7 @@ public class GetGuildChannelListApi internal constructor(guildId: ID) : GetTence
     }
     
     // GET /guilds/{guild_id}/channels
-    private val path = listOf("guilds", guildId.toString(), "channels")
+    private val path = arrayOf("guilds", guildId.toString(), "channels")
 
     override val resultDeserializer: DeserializationStrategy<List<TencentChannelInfo>>
         get() = serializer

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/permissions/GetChannelMemberPermissionsApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/permissions/GetChannelMemberPermissionsApi.kt
@@ -44,7 +44,7 @@ public class GetChannelMemberPermissionsApi internal constructor(
     }
     
     // GET /channels/{channel_id}/members/{user_id}/permissions
-    private val path = listOf("channels", channelId.toString(), "members", memberId.toString(), "permissions")
+    private val path = arrayOf("channels", channelId.toString(), "members", memberId.toString(), "permissions")
     
     override val resultDeserializer: DeserializationStrategy<TencentChannelPermissionsInfo>
         get() = TencentChannelPermissionsInfo.serializer

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/permissions/GetChannelMemberPermissionsApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/permissions/GetChannelMemberPermissionsApi.kt
@@ -28,17 +28,27 @@ import love.forte.simbot.tencentguild.api.RouteInfoBuilder
  * [获取指定子频道的权限](https://bot.q.qq.com/wiki/develop/api/openapi/channel_permissions/get_channel_permissions.html)
  * @author ForteScarlet
  */
-public class GetChannelMemberPermissionsApi(
+public class GetChannelMemberPermissionsApi internal constructor(
     channelId: ID,
     memberId: ID
 ) : GetTencentApi<TencentChannelPermissionsInfo>() {
-
+    
+    public companion object Factory {
+    
+        /**
+         * 构造 [GetChannelMemberPermissionsApi]
+         */
+        @JvmStatic
+        public fun create(channelId: ID, memberId: ID): GetChannelMemberPermissionsApi =
+            GetChannelMemberPermissionsApi(channelId, memberId)
+    }
+    
     // GET /channels/{channel_id}/members/{user_id}/permissions
     private val path = listOf("channels", channelId.toString(), "members", memberId.toString(), "permissions")
-
+    
     override val resultDeserializer: DeserializationStrategy<TencentChannelPermissionsInfo>
         get() = TencentChannelPermissionsInfo.serializer
-
+    
     override fun route(builder: RouteInfoBuilder) {
         builder.apiPath = path
     }

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/permissions/ModifyChannelMemberPermissionsApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/permissions/ModifyChannelMemberPermissionsApi.kt
@@ -89,7 +89,7 @@ public class ModifyChannelMemberPermissionsApi internal constructor(
     }
     
     // GET /channels/{channel_id}/members/{user_id}/permissions
-    private val path = listOf("channels", channelId.toString(), "members", memberId.toString(), "permissions")
+    private val path = arrayOf("channels", channelId.toString(), "members", memberId.toString(), "permissions")
     
     override val resultDeserializer: DeserializationStrategy<TencentChannelPermissionsInfo>
         get() = TencentChannelPermissionsInfo.serializer

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/permissions/ModifyChannelMemberPermissionsApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/permissions/ModifyChannelMemberPermissionsApi.kt
@@ -43,7 +43,15 @@ public class ModifyChannelMemberPermissionsApi internal constructor(
     add: Permissions? = null,
     remove: Permissions? = null,
 ) : TencentApi<TencentChannelPermissionsInfo>() {
+    
     @Api4J
+    @Deprecated(
+        "Use ModifyChannelMemberPermissionsApi.create(...)",
+        ReplaceWith(
+            "ModifyChannelMemberPermissionsApi.create(channelId, memberId, add, remove)",
+            "love.forte.simbot.tencentguild.api.channel.permissions.ModifyChannelMemberPermissionsApi.Factory.create"
+        )
+    )
     public constructor(channelId: ID, memberId: ID, add: Long, remove: Long) : this(
         channelId, memberId, Permissions(add), Permissions(remove)
     )

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/permissions/ModifyChannelMemberPermissionsApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/channel/permissions/ModifyChannelMemberPermissionsApi.kt
@@ -28,22 +28,57 @@ import love.forte.simbot.tencentguild.api.RouteInfoBuilder
 import love.forte.simbot.tencentguild.api.TencentApi
 
 /**
+ * 用于修改子频道 channel_id 下用户 user_id 的权限。
  *
- * [修改指定子频道的权限](https://bot.q.qq.com/wiki/develop/api/openapi/channel_permissions/put_channel_permissions.html)
+ * > [修改指定子频道的权限](https://bot.q.qq.com/wiki/develop/api/openapi/channel_permissions/put_channel_permissions.html)
+ *
+ * - 要求操作人具有管理子频道的权限，如果是机器人，则需要将机器人设置为管理员。
+ * - 参数包括add和remove两个字段，分别表示授予的权限以及删除的权限。要授予用户权限即把add对应位置 1，删除用户权限即把remove对应位置 1。当两个字段同一位都为 1，表现为删除权限。
+ * - 本接口不支持修改可管理子频道权限。
+ *
  * @author ForteScarlet
  */
-public class ModifyChannelMemberPermissionsApi(
+public class ModifyChannelMemberPermissionsApi internal constructor(
     channelId: ID, memberId: ID,
     add: Permissions? = null,
     remove: Permissions? = null,
 ) : TencentApi<TencentChannelPermissionsInfo>() {
     @Api4J
     public constructor(channelId: ID, memberId: ID, add: Long, remove: Long) : this(
-        channelId,
-        memberId,
-        Permissions(add),
-        Permissions(remove)
+        channelId, memberId, Permissions(add), Permissions(remove)
     )
+    
+    public companion object Factory {
+        
+        /**
+         * 构造 [ModifyChannelMemberPermissionsApi].
+         * @param add 需要追加的权限
+         * @param remove 需要移除的权限
+         */
+        @JvmStatic
+        @JvmSynthetic
+        public fun create(
+            channelId: ID, memberId: ID,
+            add: Permissions? = null,
+            remove: Permissions? = null,
+        ): ModifyChannelMemberPermissionsApi = ModifyChannelMemberPermissionsApi(channelId, memberId, add, remove)
+        
+        /**
+         * 构造 [ModifyChannelMemberPermissionsApi].
+         *
+         * @param add 需要追加的权限
+         * @param remove 需要移除的权限
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            channelId: ID, memberId: ID,
+            add: Long? = null,
+            remove: Long? = null,
+        ): ModifyChannelMemberPermissionsApi =
+            create(channelId, memberId, add?.let(::Permissions), remove?.let(::Permissions))
+        
+    }
     
     // GET /channels/{channel_id}/members/{user_id}/permissions
     private val path = listOf("channels", channelId.toString(), "members", memberId.toString(), "permissions")

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/guild/GetBotGuildListApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/guild/GetBotGuildListApi.kt
@@ -30,21 +30,71 @@ import love.forte.simbot.tencentguild.api.TencentApi
  *
  * [guilds](https://bot.q.qq.com/wiki/develop/api/openapi/user/guilds.html)
  */
-public class GetBotGuildListApi(
+public class GetBotGuildListApi internal constructor(
     /**
-     * 读此id之前的数据，before/after 只能带一个
+     * 读此id之前的数据。
+     *
+     * [before] 设置时， 先反序，再分页
      */
-    private val before: ID? = null,
+    public val before: ID?,
     
     /**
-     * 读此id之后的数据，before/after 只能带一个
+     * 读此id之后的数据。
+     *
+     * [after] 和 [before] 同时设置时， after 参数无效
      */
-    private val after: ID? = null,
+    public val after: ID?,
     /**
      * 每次拉取多少条数据	最大不超过100，默认100
      */
-    private val limit: Int = 100,
+    public val limit: Int = DEFAULT_LIMIT,
 ) : TencentApi<List<TencentGuildInfo>>() {
+    
+    public companion object Factory {
+        private val route = listOf("users", "@me", "guilds")
+        private val serializer = ListSerializer(TencentGuildInfo.serializer)
+        private const val DEFAULT_LIMIT: Int = 100
+        
+        /**
+         * 构造 [GetBotGuildListApi]
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(before: ID? = null, after: ID? = null, limit: Int = DEFAULT_LIMIT): GetBotGuildListApi =
+            GetBotGuildListApi(before, after, limit)
+        
+        /**
+         * 构造 [GetBotGuildListApi]
+         */
+        @JvmStatic
+        public fun create(limit: Int): GetBotGuildListApi =
+            GetBotGuildListApi(before = null, after = null, limit)
+        
+        
+        /**
+         * 构造 [GetBotGuildListApi]。提供 [GetBotGuildListApi.before] 属性。
+         *
+         * @param limit [GetBotGuildListApi.limit]
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun createByBefore(before: ID, limit: Int = DEFAULT_LIMIT): GetBotGuildListApi =
+            create(before = before, after = null, limit)
+        
+        
+        /**
+         * 构造 [GetBotGuildListApi]。提供 [GetBotGuildListApi.after] 属性。
+         *
+         * @param limit [GetBotGuildListApi.limit]
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun createByAfter(after: ID, limit: Int = DEFAULT_LIMIT): GetBotGuildListApi =
+            create(before = null, after = after, limit)
+        
+        
+    }
+    
     
     override val resultDeserializer: DeserializationStrategy<List<TencentGuildInfo>>
         get() = serializer
@@ -69,10 +119,6 @@ public class GetBotGuildListApi(
     override val body: Any?
         get() = null
     
-    public companion object {
-        private val route = listOf("users", "@me", "guilds")
-        private val serializer = ListSerializer(TencentGuildInfo.serializer)
-    }
 }
 
 

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/guild/GetBotGuildListApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/guild/GetBotGuildListApi.kt
@@ -51,7 +51,7 @@ public class GetBotGuildListApi internal constructor(
 ) : TencentApi<List<TencentGuildInfo>>() {
     
     public companion object Factory {
-        private val route = listOf("users", "@me", "guilds")
+        private val route = arrayOf("users", "@me", "guilds")
         private val serializer = ListSerializer(TencentGuildInfo.serializer)
         private const val DEFAULT_LIMIT: Int = 100
         

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/guild/GetGuildApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/guild/GetGuildApi.kt
@@ -38,7 +38,7 @@ public class GetGuildApi internal constructor(guildId: ID) : TencentApi<TencentG
         public fun create(guildId: ID): GetGuildApi = GetGuildApi(guildId)
     }
     
-    private val path = listOf("guilds", guildId.toString())
+    private val path = arrayOf("guilds", guildId.toString())
     
     override val resultDeserializer: DeserializationStrategy<TencentGuildInfo>
         get() = TencentGuildInfo.serializer

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/guild/GetGuildApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/guild/GetGuildApi.kt
@@ -27,7 +27,17 @@ import love.forte.simbot.tencentguild.api.TencentApi
 /**
  * 获取指定Guild
  */
-public class GetGuildApi(guildId: ID) : TencentApi<TencentGuildInfo>() {
+public class GetGuildApi internal constructor(guildId: ID) : TencentApi<TencentGuildInfo>() {
+    public companion object Factory {
+        
+        /**
+         * 构造 [GetGuildApi].
+         *
+         */
+        @JvmStatic
+        public fun create(guildId: ID): GetGuildApi = GetGuildApi(guildId)
+    }
+    
     private val path = listOf("guilds", guildId.toString())
     
     override val resultDeserializer: DeserializationStrategy<TencentGuildInfo>

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/member/GetMemberApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/member/GetMemberApi.kt
@@ -28,16 +28,25 @@ import love.forte.simbot.tencentguild.api.RouteInfoBuilder
  * [获取某个成员信息](https://bot.q.qq.com/wiki/develop/api/openapi/member/get_member.html)
  *
  */
-public class GetMemberApi(
+public class GetMemberApi internal constructor(
     guildId: ID,
     userId: ID
 ) : GetTencentApi<TencentMemberInfo>() {
+    public companion object Factory {
+        /**
+         * 构造 [GetMemberApi]
+         *
+         */
+        @JvmStatic
+        public fun create(guildId: ID, userId: ID): GetMemberApi = GetMemberApi(guildId, userId)
+    }
+    
     // GET /guilds/{guild_id}/members/{user_id}
-    private val path = listOf("guilds", guildId.toString(), "members", userId.toString())
-
+    private val path = arrayOf("guilds", guildId.toString(), "members", userId.toString())
+    
     override val resultDeserializer: DeserializationStrategy<TencentMemberInfo>
         get() = TencentMemberInfo.serializer
-
+    
     override fun route(builder: RouteInfoBuilder) {
         builder.apiPath = path
     }

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/ArkMessageTemplates.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/ArkMessageTemplates.kt
@@ -25,7 +25,7 @@ import love.forte.simbot.tencentguild.buildArk
 /**
  * 官方提供的ark消息模板。
  *
- * see https://bot.q.qq.com/wiki/develop/api/openapi/message/message_template.html
+ * [参考文档](https://bot.q.qq.com/wiki/develop/api/openapi/message/message_template.html)
  *
  */
 public sealed class ArkMessageTemplates {
@@ -66,7 +66,6 @@ public sealed class ArkMessageTemplates {
                         }
                     }
                 }
-
             }
         }
 

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/GetMessageApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/GetMessageApi.kt
@@ -31,7 +31,7 @@ import love.forte.simbot.tencentguild.api.RouteInfoBuilder
  */
 public class GetMessageApi(channelId: ID, messageId: ID) : GetTencentApi<TencentMessage>() {
     // GET /channels/{channel_id}/messages/{message_id}
-    private val path = listOf("channels", channelId.toString(), "messages", messageId.toString())
+    private val path = arrayOf("channels", channelId.toString(), "messages", messageId.toString())
 
     override val resultDeserializer: DeserializationStrategy<TencentMessage>
         get() = TencentMessage.serializer

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/GetMessageApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/GetMessageApi.kt
@@ -29,13 +29,21 @@ import love.forte.simbot.tencentguild.api.RouteInfoBuilder
  *
  * @author ForteScarlet
  */
-public class GetMessageApi(channelId: ID, messageId: ID) : GetTencentApi<TencentMessage>() {
+public class GetMessageApi internal constructor(channelId: ID, messageId: ID) : GetTencentApi<TencentMessage>() {
+    public companion object Factory {
+        /**
+         * 构造 [GetMessageApi]
+         */
+        @JvmStatic
+        public fun create(channelId: ID, messageId: ID): GetMessageApi = GetMessageApi(channelId, messageId)
+    }
+    
     // GET /channels/{channel_id}/messages/{message_id}
     private val path = arrayOf("channels", channelId.toString(), "messages", messageId.toString())
-
+    
     override val resultDeserializer: DeserializationStrategy<TencentMessage>
         get() = TencentMessage.serializer
-
+    
     override fun route(builder: RouteInfoBuilder) {
         builder.apiPath = path
     }

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/direct/CreateDmsApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/direct/CreateDmsApi.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.ID
+import love.forte.simbot.literal
 import love.forte.simbot.tencentguild.DirectMessageSession
 import love.forte.simbot.tencentguild.api.RouteInfoBuilder
 import love.forte.simbot.tencentguild.api.TencentApi
@@ -46,10 +47,22 @@ import love.forte.simbot.tencentguild.api.TencentApi
  *
  * @author ForteScarlet
  */
-public class CreateDmsApi(
+public class CreateDmsApi internal constructor(
     recipientId: ID,
     sourceGuildId: ID,
 ) : TencentApi<DirectMessageSession>() {
+    public companion object Factory {
+        // POST /users/@me/dms
+        private val path = arrayOf("users", "@me", "dms")
+    
+        /**
+         * 构造 [CreateDmsApi].
+         *
+         */
+        @JvmStatic
+        public fun create(recipientId: ID, sourceGuildId: ID): CreateDmsApi = CreateDmsApi(recipientId, sourceGuildId)
+    }
+    
     override val resultDeserializer: DeserializationStrategy<DirectMessageSession>
         get() = DirectMessageSession.serializer
     
@@ -57,22 +70,17 @@ public class CreateDmsApi(
         get() = HttpMethod.Post
     
     override fun route(builder: RouteInfoBuilder) {
-        builder.apiPath = route
+        builder.apiPath = path
         builder.contentType
     }
     
-    private val _body = Body(recipientId, sourceGuildId)
+    private val _body = Body(recipientId.literal, sourceGuildId.literal)
     
     override val body: Any get() = _body
     
     @Serializable
     private data class Body(
-        @Serializable(ID.AsCharSequenceIDSerializer::class) @SerialName("recipient_id") private val recipientId: ID,
-        @Serializable(ID.AsCharSequenceIDSerializer::class) @SerialName("source_guild_id") private val sourceGuildId: ID,
+        @SerialName("recipient_id") private val recipientId: String,
+        @SerialName("source_guild_id") private val sourceGuildId: String,
     )
-    
-    public companion object {
-        // POST /users/@me/dms
-        private val route = listOf("users", "@me", "dms")
-    }
 }

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/direct/DeleteDmsApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/direct/DeleteDmsApi.kt
@@ -44,18 +44,31 @@ import love.forte.simbot.tencentguild.api.TencentApi
  * * 注意: 开通后需要先将机器人从频道移除，然后重新添加，方可生效。
  *
  *
- *
+ * @param hidetip 是否隐藏提示小灰条，`true` 为隐藏，`false` 为显示。默认为 `false`
  *
  *
  *
  *
  * @author ForteScarlet
  */
-public class DeleteDmsApi @JvmOverloads constructor(
+public class DeleteDmsApi internal constructor(
     guildId: ID,
     messageId: ID,
     private val hidetip: Boolean = false,
 ) : TencentApi<Unit>() {
+    public companion object Factory {
+        
+        /**
+         * 构造 [DeleteDmsApi]
+         *
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID, messageId: ID, hidetip: Boolean = false): DeleteDmsApi =
+            DeleteDmsApi(guildId, messageId, hidetip)
+        
+    }
+    
     override val resultDeserializer: DeserializationStrategy<Unit>
         get() = Unit.serializer()
     
@@ -63,10 +76,10 @@ public class DeleteDmsApi @JvmOverloads constructor(
         get() = HttpMethod.Delete
     
     // /dms/{guild_id}/messages/{message_id}
-    private val route = listOf("dms", guildId.literal, "messages", messageId.literal)
+    private val path = arrayOf("dms", guildId.literal, "messages", messageId.literal)
     
     override fun route(builder: RouteInfoBuilder) {
-        builder.apiPath = route
+        builder.apiPath = path
         builder.parametersAppender.append("hidetip", hidetip)
     }
     

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/direct/DmsSendApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/message/direct/DmsSendApi.kt
@@ -59,30 +59,73 @@ public class DmsSendApi private constructor(
     guildId: ID,
     override val body: Any, // TencentMessageForSending || MultiPartFormDataContent
 ) : TencentApi<TencentMessage>() {
-    @JvmOverloads
-    public constructor(guildId: ID, content: String, msgId: ID? = null) : this(
-        guildId,
-        TencentMessageForSending(content = content, msgId = msgId)
-    )
+    public companion object Factory {
+        
+        /**
+         * 构造 [DmsSendApi]
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID, content: String, msgId: ID? = null): DmsSendApi {
+            return DmsSendApi(guildId, TencentMessageForSending(content = content, msgId = msgId))
+        }
+        
+        /**
+         * 构造 [DmsSendApi]
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID, embed: TencentMessage.Embed, msgId: ID? = null): DmsSendApi {
+            return DmsSendApi(guildId, TencentMessageForSending(embed = embed, msgId = msgId))
+        }
+        
+        
+        /**
+         * 构造 [DmsSendApi]
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID, ark: TencentMessage.Ark, msgId: ID? = null): DmsSendApi {
+            return DmsSendApi(guildId, TencentMessageForSending(ark = ark, msgId = msgId))
+        }
+        
+        // with 'fileImage'
+        
+        
+        /**
+         * 构造 [DmsSendApi]
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(guildId: ID, sendingBody: TencentMessageForSending, fileImage: Resource? = null): DmsSendApi =
+            DmsSendApi(
+                guildId = guildId,
+                body = if (fileImage != null) sendingBody.toMultiPartFormDataContent(
+                    MessageSendApi.defaultJson,
+                    fileImage
+                ) else sendingBody
+            )
+        
+        
+        /**
+         * 构造 [DmsSendApi]
+         */
+        @JvmStatic
+        public fun create(guildId: ID, fileImage: Resource): DmsSendApi = DmsSendApi(
+            guildId = guildId,
+            body = null.toMultiPartFormDataContent(MessageSendApi.defaultJson, fileImage)
+        )
+        
+    }
     
-    @JvmOverloads
-    public constructor(guildId: ID, embed: TencentMessage.Embed, msgId: ID? = null) : this(
-        guildId,
-        TencentMessageForSending(embed = embed, msgId = msgId)
-    )
-    
-    @JvmOverloads
-    public constructor(guildId: ID, ark: TencentMessage.Ark, msgId: ID? = null) : this(
-        guildId,
-        TencentMessageForSending(ark = ark, msgId = msgId)
-    )
-    
-    // with 'fileImage'
     
     @JvmOverloads
     public constructor(guildId: ID, sendingBody: TencentMessageForSending, fileImage: Resource? = null) : this(
         guildId = guildId,
-        body = if (fileImage != null) sendingBody.toMultiPartFormDataContent(MessageSendApi.defaultJson, fileImage) else sendingBody
+        body = if (fileImage != null) sendingBody.toMultiPartFormDataContent(
+            MessageSendApi.defaultJson,
+            fileImage
+        ) else sendingBody
     )
     
     
@@ -93,7 +136,7 @@ public class DmsSendApi private constructor(
     
     
     // POST /channels/{channel_id}/messages
-    private val path: List<String> = listOf("dms", guildId.literal, "messages")
+    private val path = arrayOf("dms", guildId.literal, "messages")
     
     override val resultDeserializer: DeserializationStrategy<TencentMessage>
         get() = SendMessageResult.serializer()

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/AddMemberRoleApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/AddMemberRoleApi.kt
@@ -29,11 +29,20 @@ import love.forte.simbot.tencentguild.api.TencentApiWithoutResult
  *
  * @author ForteScarlet
  */
-public class AddMemberRoleApi(
+public class AddMemberRoleApi internal constructor(
     channelId: ID, guildId: ID,
     userId: ID, roleId: ID,
 ) : TencentApiWithoutResult() {
-    private val _body = Body(channelId.toString())
+    public companion object Factory {
+        
+        /**
+         * 构造 [AddMemberRoleApi]
+         *
+         */
+        @JvmStatic
+        public fun create(channelId: ID, guildId: ID, userId: ID, roleId: ID): AddMemberRoleApi =
+            AddMemberRoleApi(channelId, guildId, userId, roleId)
+    }
     
     // PUT /guilds/{guild_id}/members/{user_id}/roles/{role_id}
     private val path = arrayOf(
@@ -52,7 +61,7 @@ public class AddMemberRoleApi(
         builder.apiPath = path
     }
     
-    override val body: Any get() = _body
+    override val body: Any = Body(channelId.toString())
     
     /** 接收一个只填充了子频道id字段的对象 */
     @Serializable

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/AddMemberRoleApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/AddMemberRoleApi.kt
@@ -36,7 +36,7 @@ public class AddMemberRoleApi(
     private val _body = Body(channelId.toString())
     
     // PUT /guilds/{guild_id}/members/{user_id}/roles/{role_id}
-    private val path = listOf(
+    private val path = arrayOf(
         "guilds",
         guildId.toString(),
         "members",

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/CreateGuildRoleApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/CreateGuildRoleApi.kt
@@ -38,19 +38,28 @@ public class CreateGuildRoleApi internal constructor(
     guildId: ID,
     private val _body: Body,
 ) : TencentApi<GuildRoleCreated>() {
-    @JvmOverloads
-    public constructor(
-        guildId: ID,
-        filter: GuildRoleFilter = defBody.filter,
-        info: GuildRoleInfo = defBody.info,
-    ) : this(
-        guildId,
-        if (filter === defBody.filter && info === defBody.info) defBody
-        else Body(filter, info)
-    )
+    
+    public companion object Factory {
+        private val defBody = Body(GuildRoleFilter.default, GuildRoleInfo.default)
+        
+        /**
+         * 构造 [CreateGuildRoleApi]
+         *
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            guildId: ID,
+            filter: GuildRoleFilter = defBody.filter,
+            info: GuildRoleInfo = defBody.info
+        ): CreateGuildRoleApi = CreateGuildRoleApi(
+            guildId,
+            if (filter === defBody.filter && info === defBody.info) defBody
+            else Body(filter, info)
+        )
+    }
     
     private val path = arrayOf("guilds", guildId.toString(), "roles")
-    
     
     override val resultDeserializer: DeserializationStrategy<GuildRoleCreated> get() = GuildRoleCreated.serializer
     override val method: HttpMethod get() = HttpMethod.Post
@@ -60,10 +69,6 @@ public class CreateGuildRoleApi internal constructor(
     }
     
     override val body: Any get() = _body
-    
-    public companion object {
-        private val defBody = Body(GuildRoleFilter.default, GuildRoleInfo.default)
-    }
     
     
     @Serializable

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/CreateGuildRoleApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/CreateGuildRoleApi.kt
@@ -49,7 +49,7 @@ public class CreateGuildRoleApi internal constructor(
         else Body(filter, info)
     )
     
-    private val path = listOf("guilds", guildId.toString(), "roles")
+    private val path = arrayOf("guilds", guildId.toString(), "roles")
     
     
     override val resultDeserializer: DeserializationStrategy<GuildRoleCreated> get() = GuildRoleCreated.serializer

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/DeleteGuildRoleApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/DeleteGuildRoleApi.kt
@@ -31,6 +31,15 @@ import love.forte.simbot.tencentguild.api.TencentApiWithoutResult
  * @author ForteScarlet
  */
 public class DeleteGuildRoleApi(guildId: ID, roleId: ID) : TencentApiWithoutResult() {
+    public companion object Factory {
+        
+        /**
+         * 构造 [DeleteGuildRoleApi]
+         */
+        @JvmStatic
+        public fun create(guildId: ID, roleId: ID): DeleteGuildRoleApi = DeleteGuildRoleApi(guildId, roleId)
+    }
+    
     private val path = arrayOf("guilds", guildId.toString(), "roles", roleId.toString())
     
     override val method: HttpMethod

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/DeleteGuildRoleApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/DeleteGuildRoleApi.kt
@@ -31,7 +31,7 @@ import love.forte.simbot.tencentguild.api.TencentApiWithoutResult
  * @author ForteScarlet
  */
 public class DeleteGuildRoleApi(guildId: ID, roleId: ID) : TencentApiWithoutResult() {
-    private val path = listOf("guilds", guildId.toString(), "roles", roleId.toString())
+    private val path = arrayOf("guilds", guildId.toString(), "roles", roleId.toString())
     
     override val method: HttpMethod
         get() = HttpMethod.Delete

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/GetGuildRoleListApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/GetGuildRoleListApi.kt
@@ -27,19 +27,26 @@ import love.forte.simbot.tencentguild.api.*
  * [获取频道身份组列表](https://bot.q.qq.com/wiki/develop/api/openapi/guild/get_guild_roles.html#%E8%8E%B7%E5%8F%96%E9%A2%91%E9%81%93%E8%BA%AB%E4%BB%BD%E7%BB%84%E5%88%97%E8%A1%A8)
  * @author ForteScarlet
  */
-public class GetGuildRoleListApi(guildId: ID) : GetTencentApi<GuildRoleList>() {
-
+public class GetGuildRoleListApi internal constructor(guildId: ID) : GetTencentApi<GuildRoleList>() {
+    public companion object Factory {
+        private val serializer = GuildRoleList.serializer()
+        
+        /**
+         * 构造 [GetGuildRoleListApi]
+         *
+         */
+        @JvmStatic
+        public fun create(guildId: ID): GetGuildRoleListApi = GetGuildRoleListApi(guildId)
+    }
+    
     override val resultDeserializer: DeserializationStrategy<GuildRoleList> = serializer
-
+    
     override fun route(builder: RouteInfoBuilder) {
         builder.apiPath = path
     }
-
-    private val path = arrayOf("/guilds", guildId.toString(), "roles")
-
-    public companion object {
-        private val serializer = GuildRoleList.serializer()
-    }
+    
+    private val path = arrayOf("guilds", guildId.toString(), "roles")
+    
 }
 
 @Serializable

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/GetGuildRoleListApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/GetGuildRoleListApi.kt
@@ -35,7 +35,7 @@ public class GetGuildRoleListApi(guildId: ID) : GetTencentApi<GuildRoleList>() {
         builder.apiPath = path
     }
 
-    private val path = listOf("/guilds", guildId.toString(), "roles")
+    private val path = arrayOf("/guilds", guildId.toString(), "roles")
 
     public companion object {
         private val serializer = GuildRoleList.serializer()

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/ModifyGuildRoleApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/ModifyGuildRoleApi.kt
@@ -36,22 +36,29 @@ public class ModifyGuildRoleApi private constructor(
     roleId: ID,
     private val _body: Body,
 ) : TencentApi<GuildRoleModified>() {
-    public constructor(
-        guildId: ID,
-        roleId: ID,
-        filter: GuildRoleFilter,
-        info: GuildRoleInfo,
-    ) : this(
-        guildId,
-        roleId,
-        if (filter === defBody.filter && info === defBody.info) defBody
-        else Body(filter, info)
-    )
+    
+    public companion object Factory {
+        private val serializer = GuildRoleModified.serializer()
+        private val defBody = Body(GuildRoleFilter.default, GuildRoleInfo.default)
+        
+        /**
+         * 构造 [ModifyGuildRoleApi]
+         *
+         */
+        @JvmStatic
+        public fun create(
+            guildId: ID, roleId: ID, filter: GuildRoleFilter, info: GuildRoleInfo
+        ): ModifyGuildRoleApi = ModifyGuildRoleApi(
+            guildId, roleId, if (filter === defBody.filter && info === defBody.info) defBody
+            else Body(filter, info)
+        )
+    }
     
     private val path = arrayOf("guilds", guildId.toString(), "roles", roleId.toString())
     
     override val resultDeserializer: DeserializationStrategy<GuildRoleModified>
         get() = serializer
+    
     override val method: HttpMethod
         get() = HttpMethod.Patch
     
@@ -61,10 +68,6 @@ public class ModifyGuildRoleApi private constructor(
     
     override val body: Any get() = _body
     
-    public companion object {
-        private val serializer = GuildRoleModified.serializer()
-        private val defBody = Body(GuildRoleFilter.default, GuildRoleInfo.default)
-    }
     
     @Serializable
     private data class Body(val filter: GuildRoleFilter, val info: GuildRoleInfo)
@@ -75,14 +78,12 @@ public data class GuildRoleModified(
     /**
      * 频道ID
      */
-    @SerialName("guild_id")
-    public val guildId: CharSequenceID,
+    @SerialName("guild_id") public val guildId: CharSequenceID,
     
     /**
      * 身份组ID
      */
-    @SerialName("role_id")
-    public val roleId: CharSequenceID,
+    @SerialName("role_id") public val roleId: CharSequenceID,
     
     /**
      * 修改后的频道身份组对象

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/ModifyGuildRoleApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/ModifyGuildRoleApi.kt
@@ -48,7 +48,7 @@ public class ModifyGuildRoleApi private constructor(
         else Body(filter, info)
     )
     
-    private val path = listOf("guilds", guildId.toString(), "roles", roleId.toString())
+    private val path = arrayOf("guilds", guildId.toString(), "roles", roleId.toString())
     
     override val resultDeserializer: DeserializationStrategy<GuildRoleModified>
         get() = serializer

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/RemoveMemberRoleApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/RemoveMemberRoleApi.kt
@@ -36,7 +36,7 @@ public class RemoveMemberRoleApi(
     private val _body = Body(channelId.toString())
     
     // DELETE /guilds/{guild_id}/members/{user_id}/roles/{role_id}
-    private val path = listOf(
+    private val path = arrayOf(
         "guilds",
         guildId.toString(),
         "members",

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/RemoveMemberRoleApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/role/RemoveMemberRoleApi.kt
@@ -28,12 +28,22 @@ import love.forte.simbot.tencentguild.api.TencentApiWithoutResult
  *
  * @author ForteScarlet
  */
-public class RemoveMemberRoleApi(
+public class RemoveMemberRoleApi internal constructor(
     channelId: ID, guildId: ID,
     userId: ID, roleId: ID,
 ) : TencentApiWithoutResult() {
-    
-    private val _body = Body(channelId.toString())
+    public companion object Factory {
+        
+        /**
+         * 构造 [RemoveMemberRoleApi]
+         *
+         */
+        @JvmStatic
+        public fun create(
+            channelId: ID, guildId: ID,
+            userId: ID, roleId: ID,
+        ): RemoveMemberRoleApi = RemoveMemberRoleApi(channelId, guildId, userId, roleId)
+    }
     
     // DELETE /guilds/{guild_id}/members/{user_id}/roles/{role_id}
     private val path = arrayOf(
@@ -52,7 +62,7 @@ public class RemoveMemberRoleApi(
         builder.apiPath = path
     }
     
-    override val body: Any get() = _body
+    override val body: Any = Body(channelId.toString())
     
     /** 接收一个只填充了子频道id字段的对象 */
     @Serializable

--- a/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/user/GetBotInfoApi.kt
+++ b/simbot-component-tencent-guild-api/src/main/kotlin/love/forte/simbot/tencentguild/api/user/GetBotInfoApi.kt
@@ -30,7 +30,7 @@ import love.forte.simbot.tencentguild.api.RouteInfoBuilder
  */
 public object GetBotInfoApi : GetTencentApi<TencentBotInfo>() {
     // GET /users/@me
-    private val path = listOf("users", "@me")
+    private val path = arrayOf("users", "@me")
     override val resultDeserializer: DeserializationStrategy<TencentBotInfo> = TencentBotInfo.serializer
     override fun route(builder: RouteInfoBuilder) {
         builder.apiPath = path

--- a/simbot-component-tencent-guild-api/src/test/kotlin/test/ApiTest.kt
+++ b/simbot-component-tencent-guild-api/src/test/kotlin/test/ApiTest.kt
@@ -35,7 +35,7 @@ class ApiTest {
     
     suspend fun run() {
         // 得到一个api请求对象
-        val api = GetBotGuildListApi(before = null, after = null, limit = 10)
+        val api = GetBotGuildListApi.create(before = null, after = null, limit = 10)
         
         val guildList: List<TencentGuildInfo> = api.request(
             client = client,

--- a/simbot-component-tencent-guild-api/src/test/kotlin/test/JobTest.kt
+++ b/simbot-component-tencent-guild-api/src/test/kotlin/test/JobTest.kt
@@ -18,6 +18,7 @@
 package test
 
 import kotlinx.coroutines.*
+import love.forte.simbot.utils.runInNoScopeBlocking
 import kotlin.test.Test
 
 /**
@@ -27,7 +28,7 @@ import kotlin.test.Test
 class JobTest {
 
     @Test
-    fun test(): Unit = runBlocking {
+    fun test(): Unit = runInNoScopeBlocking {
         val pJob = Job()
 
 

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/TencentGuildComponent.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/TencentGuildComponent.kt
@@ -27,7 +27,7 @@ import love.forte.simbot.message.Message
 
 
 /**
- * 腾讯频道实现simbot相关组件的基本组件信息，可以用来获取组件ID、组件所用序列化器等等。
+ * QQ频道实现simbot相关组件的基本组件信息，可以用来获取组件ID、组件所用序列化器等等。
  *
  * @author ForteScarlet
  */
@@ -86,7 +86,7 @@ public class TencentGuildComponent : Component {
         }
         
         /**
-         * 腾讯频道组件所使用到的特殊消息类型序列化信息。
+         * QQ频道组件所使用到的特殊消息类型序列化信息。
          */
         @JvmStatic
         public val messageSerializersModule: SerializersModule = SerializersModule {

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/TencentGuildComponentBot.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/TencentGuildComponentBot.kt
@@ -38,7 +38,7 @@ import love.forte.simbot.utils.item.Items.Companion.emptyItems
  */
 public interface TencentGuildComponentBot : Bot {
     /**
-     * 腾讯频道的 [组件][TencentGuildComponent] 对象实例。
+     * QQ频道的 [组件][TencentGuildComponent] 对象实例。
      */
     override val component: TencentGuildComponent
     
@@ -143,7 +143,7 @@ public interface TencentGuildComponentBot : Bot {
 
 
 /**
- * 腾讯频道组件中 [TencentGuildComponentBot] 对 [GuildBot] 的实现。
+ * QQ频道组件中 [TencentGuildComponentBot] 对 [GuildBot] 的实现。
  *
  */
 public interface TencentGuildComponentGuildBot : TencentGuildComponentBot, GuildBot {

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/TencentRole.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/TencentRole.kt
@@ -22,7 +22,7 @@ import love.forte.simbot.definition.Role
 import love.forte.simbot.tencentguild.TencentRoleInfo
 
 /**
- * 腾讯频道中所使用的角色类型。
+ * QQ频道中所使用的角色类型。
  * @author ForteScarlet
  */
 public interface TencentRole : Role, TencentRoleInfo {

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/event/TcgEvent.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/event/TcgEvent.kt
@@ -29,7 +29,7 @@ import love.forte.simbot.tencentguild.EventSignals
 
 /**
  *
- * 腾讯频道bot的事件总类。
+ * QQ频道bot的事件总类。
  *
  * @param T 此类型代表其真正事件所得到的结果。
  *

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/MessageAsReceipt.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/MessageAsReceipt.kt
@@ -25,7 +25,7 @@ import love.forte.simbot.tencentguild.TencentMessage
 
 public interface TencentMessageReceipt : MessageReceipt {
     /**
-     * 腾讯频道消息发送api发送消息后得到的回执，也就是消息对象。
+     * QQ频道消息发送api发送消息后得到的回执，也就是消息对象。
      */
     public val messageResult: TencentMessage
 }

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/TencentChannelImpl.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/TencentChannelImpl.kt
@@ -63,7 +63,7 @@ internal class TencentChannelImpl internal constructor(
                 }
             }
         }
-        return MessageSendApi(source.id, messageForSend, fileImage).requestBy(baseBot).asReceipt()
+        return MessageSendApi.create(source.id, messageForSend, fileImage).requestBy(baseBot).asReceipt()
     }
     
     

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/TencentGuildComponentBotImpl.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/TencentGuildComponentBotImpl.kt
@@ -142,7 +142,7 @@ private suspend fun TencentGuildComponentBotImpl.initGuildListData() {
     var times = 1
     val guildInfoList = mutableListOf<TencentGuildInfo>()
     while (true) {
-        val list = GetBotGuildListApi(after = lastId).requestBy(source)
+        val list = GetBotGuildListApi.create(after = lastId).requestBy(source)
         if (list.isEmpty()) break
         
         logger.debug(

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/TencentGuildImpl.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/TencentGuildImpl.kt
@@ -115,7 +115,7 @@ internal class TencentGuildImpl private constructor(
     
     
     override suspend fun member(id: ID): TencentMemberImpl? {
-        val member = kotlin.runCatching { GetMemberApi(source.id, id).requestBy(baseBot) }.getOrElse { e ->
+        val member = kotlin.runCatching { GetMemberApi.create(source.id, id).requestBy(baseBot) }.getOrElse { e ->
             if (e is TencentApiException && e.value == 404) return@getOrElse null
             
             throw e
@@ -126,7 +126,7 @@ internal class TencentGuildImpl private constructor(
     
     override val roles: Items<TencentRoleImpl>
         get() = bot.effectedFlowItems {
-            GetGuildRoleListApi(source.id).requestBy(baseBot).roles.forEach { info ->
+            GetGuildRoleListApi.create(source.id).requestBy(baseBot).roles.forEach { info ->
                 val roleImpl = TencentRoleImpl(baseBot, info)
                 emit(roleImpl)
             }
@@ -159,7 +159,7 @@ internal class TencentGuildImpl private constructor(
     
     private suspend fun syncOwner() {
         val ownerId = source.ownerId
-        val ownerInfo = GetMemberApi(source.id, ownerId).requestBy(baseBot)
+        val ownerInfo = GetMemberApi.create(source.id, ownerId).requestBy(baseBot)
         
         ownerInternal = TencentMemberImpl(baseBot, ownerInfo, this)
         logger.debug("Sync guild owner: {}", ownerInfo)

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/TencentGuildImpl.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/TencentGuildImpl.kt
@@ -174,7 +174,7 @@ internal class TencentGuildImpl private constructor(
     
     
     private suspend fun syncChannels() {
-        val channelInfoList = GetGuildChannelListApi(source.id).requestBy(baseBot).sortedBy {
+        val channelInfoList = GetGuildChannelListApi.create(source.id).requestBy(baseBot).sortedBy {
             if (it.channelType.isGrouping) 0 else 1
         }
         

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/TencentMemberImpl.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/TencentMemberImpl.kt
@@ -73,7 +73,7 @@ internal class TencentMemberImpl(
                 if (::dms.isInitialized) {
                     return dms
                 }
-                return CreateDmsApi(id, _guild.id).requestBy(bot).also {
+                return CreateDmsApi.create(id, _guild.id).requestBy(bot).also {
                     dms = it
                 }
             }
@@ -119,7 +119,7 @@ internal class TencentMemberImpl(
             currentCoroutineContext()[EventProcessingContext]?.event?.takeIf { it is TcgChannelAtMessageEvent } as? TcgChannelAtMessageEvent
         val msgId = currentEvent?.sourceEventEntity?.id
         
-        return DmsSendApi(guildId = dms.guildId, content = text, msgId = msgId).requestBy(bot).asReceipt()
+        return DmsSendApi.create(guildId = dms.guildId, content = text, msgId = msgId).requestBy(bot).asReceipt()
     }
     
     

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/event/DispatchPushUtil.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/event/DispatchPushUtil.kt
@@ -88,14 +88,14 @@ internal val eventSignalParsers =
 internal suspend fun TencentGuildComponentBotImpl.createGuildImpl(
     guildId: ID,
 ): TencentGuildImpl {
-    val guild = GetGuildApi(guildId).requestBy(source)
+    val guild = GetGuildApi.create(guildId).requestBy(source)
     return tencentGuildImpl(this, guild)
 }
 
 internal suspend fun TencentGuildComponentBotImpl.createChannelImpl(
     guild: TencentGuildImpl, channelId: ID,
 ): TencentChannelImpl {
-    val channel = GetChannelApi(channelId).requestBy(source)
+    val channel = GetChannelApi.create(channelId).requestBy(source)
     val category = resolveCategory(guild, channel.parentId.ID)
     return TencentChannelImpl(this, channel, guild, category)
 }
@@ -106,7 +106,7 @@ internal suspend fun TencentGuildComponentBotImpl.resolveCategory(
 ): TencentChannelCategoryImpl {
     val idValue = id.literal
     return guild.internalChannelCategories[idValue] ?: run {
-        val categoryInfo = GetChannelApi(id).requestBy(source)
+        val categoryInfo = GetChannelApi.create(id).requestBy(source)
         guild.internalChannelCategories.compute(id.literal) { _, current ->
             current?.also {
                 it.channel = categoryInfo

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/event/TcgChannelAtMessageEventImpl.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/internal/event/TcgChannelAtMessageEventImpl.kt
@@ -42,7 +42,7 @@ internal class TcgChannelAtMessageEventImpl(
         val (messageForSend, fileImage) = MessageParsers.parse(message)
         messageForSend.msgId = sourceEventEntity.id
         val cid = sourceEventEntity.channelId
-        return MessageSendApi(cid, messageForSend, fileImage).requestBy(bot).asReceipt()
+        return MessageSendApi.create(cid, messageForSend, fileImage).requestBy(bot).asReceipt()
     }
     
     override suspend fun send(message: Message): MessageReceipt = reply(message)

--- a/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/message/TcgReplyTo.kt
+++ b/simbot-component-tencent-guild-core/src/main/kotlin/love/forte/simbot/component/tencentguild/message/TcgReplyTo.kt
@@ -28,7 +28,7 @@ import love.forte.simbot.message.doSafeCast
 
 /**
  *
- * 腾讯频道机器人为公域时可能需要指定一个回复消息的目标，通过拼接 [TcgReplyTo] 到当前消息列表中来提供一个回复消息的目标信息。
+ * QQ频道机器人为公域时可能需要指定一个回复消息的目标，通过拼接 [TcgReplyTo] 到当前消息列表中来提供一个回复消息的目标信息。
  *
  * @author ForteScarlet
  */

--- a/simbot-component-tencent-guild-stdlib/src/main/kotlin/love/forte/simbot/tencentguild/BotRequestUtil.kt
+++ b/simbot-component-tencent-guild-stdlib/src/main/kotlin/love/forte/simbot/tencentguild/BotRequestUtil.kt
@@ -22,6 +22,7 @@ package love.forte.simbot.tencentguild
 import kotlinx.coroutines.*
 import love.forte.simbot.*
 import love.forte.simbot.tencentguild.api.*
+import love.forte.simbot.utils.runInNoScopeBlocking
 
 
 /**
@@ -63,7 +64,7 @@ public suspend fun <R> TencentGuildBot.request(api: TencentApi<R>): R = api.requ
  * @throws love.forte.simbot.tencentguild.TencentApiException 如果返回状态码不在 200..300之间。
  */
 @Api4J
-public fun <R> doRequest(bot: TencentGuildBot, api: TencentApi<R>): R = runBlocking {
+public fun <R> doRequest(bot: TencentGuildBot, api: TencentApi<R>): R = runInNoScopeBlocking {
     api.requestBy(bot)
 }
 

--- a/simbot-component-tencent-guild-stdlib/src/test/kotlin/BotTest.kt
+++ b/simbot-component-tencent-guild-stdlib/src/test/kotlin/BotTest.kt
@@ -16,8 +16,8 @@
  */
 
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.runBlocking
 import love.forte.simbot.tencentguild.tencentGuildBot
+import love.forte.simbot.utils.runInNoScopeBlocking
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
@@ -29,7 +29,7 @@ import kotlin.concurrent.thread
 class BotTest {
 
 
-    fun test() = runBlocking {
+    fun test() = runInNoScopeBlocking {
 
         // 直接构建一个BOT
         val bot = tencentGuildBot(

--- a/simbot-component-tencent-guild-stdlib/src/test/kotlin/ShowMain1.kt
+++ b/simbot-component-tencent-guild-stdlib/src/test/kotlin/ShowMain1.kt
@@ -64,7 +64,7 @@ suspend fun main() {
     bot.processor(EventSignals.AtMessages.AtMessageCreate) { message ->
         println(message)
 
-        val api = MessageSendApi(channelId = message.channelId, content = "content", msgId = message.id)
+        val api = MessageSendApi.create(channelId = message.channelId, content = "content", msgId = message.id)
         // 发送回复消息
         val result = api.requestBy(bot)
         println(result)


### PR DESCRIPTION
使用工厂函数的应用代替原本直接构造API的方式（并且所有相关API的伴生对象均命名为 `Factory`）。**这是不兼容的变更**

例如原本可能：

```kotlin
val api = FooApi(xx, xx)
...
```

则现在为 

```kotlin
val api = FooApi.create(xx, xx)
...
```

少量 `object` 类型的API无变化，少量API额外提供更多 `create` 相关的重载或扩展，例如 `XxxApi.createByNumber(xxx)`

工厂形式更容易维护与扩展，隐藏的构造目前以 `internal` 的级别**一定程度上**的提供二进制兼容，后续会在 `beta` 版本阶段全部变更为 `private` 访问级别。